### PR TITLE
Ignore node_modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Dependency directory
+node_modules/


### PR DESCRIPTION
I ran `npm i` and looks like a bunch of files in the vendored `node_modules` were nuked. It immediately generated a large diff, which wasn't really a reflection of the truth. I think ignoring `node_modules` will solve this problem.

Good thing there's a `package-lock.json`, which will always give the correct dependencies. As such, it might not be a good idea to vendor `node_modules`. But I could have missed the reasoning behind why it was vendored.