### PR TITLE
Fix BVN Verification Bug in Lib Folder

### DIFF
--- a/lib/rave.bvn.js
+++ b/lib/rave.bvn.js
@@ -1,5 +1,5 @@
 
-var bvnVerification= require('../services/'); 
+var bvnVerification= require('../services/rave.bvnVerification');
 
 function Bvn(RaveBase){
 


### PR DESCRIPTION
Wrong file path in the Lib folder was assigned to "bvnVerification" variable, thus users can't use the BVN feature on the SDK.
This has been fixed now and users can proceed to use the BVN feature.